### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+install: "pip install . --use-mirrors"
+script: "python setup.py test"

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,7 @@
 richenum
 ========
 
+.. image:: https://travis-ci.org/hearsaycorp/richenum.png
+    :alt: Build Status
+
 A enum library for Python


### PR DESCRIPTION
Continuous integration via Travis CI. Before merging this, the hearsaycorp Github account owner (@adepue?) will need to set up an account on [Travis](http://travis-ci.org). Setting up an account gives Travis access to all our public repos, but none of the private ones, so it shouldn't be a security problem.
