### PR TITLE
Make Travis test only against Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
 install: "pip install . --use-mirrors"
 script: "python setup.py test"


### PR DESCRIPTION
We should probably make this Python 2.6- and 3.x-compatible at some point, but for now we only support 2.7.
