### PR TITLE
Raise warnings on comparisons to other types

### DIFF
--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import new
+import warnings
 
 from operator import itemgetter
 
@@ -15,6 +16,13 @@ class EnumConstructionException(Exception):
 class EnumLookupError(Exception):
     """
     Raised when an enum cannot be found by the specified method of lookup.
+    """
+    pass
+
+
+class EnumComparisonWarning(Warning):
+    """
+    Raised when comparing an enum to a value of another type.
     """
     pass
 
@@ -67,11 +75,17 @@ class RichEnumValue(object):
 
     def __cmp__(self, other):
         if not isinstance(other, type(self)):
+            warnings.warn(
+                'Comparing a %s to a %s!' % (type(other), type(self)),
+                EnumComparisonWarning)
             return -1
         return cmp(self.canonical_name, other.canonical_name)
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
+            warnings.warn(
+                'Comparing a %s to a %s!' % (type(other), type(self)),
+                EnumComparisonWarning)
             return False
         return self.canonical_name == other.canonical_name
 
@@ -107,11 +121,17 @@ class OrderedRichEnumValue(RichEnumValue):
 
     def __cmp__(self, other):
         if not isinstance(other, type(self)):
+            warnings.warn(
+                'Comparing a %s to a %s!' % (type(other), type(self)),
+                EnumComparisonWarning)
             return -1
         return cmp(self.index, other.index)
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
+            warnings.warn(
+                'Comparing a %s to a %s!' % (type(other), type(self)),
+                EnumComparisonWarning)
             return False
         return self.index == other.index
 

--- a/tests/richenum/test_ordered_rich_enums.py
+++ b/tests/richenum/test_ordered_rich_enums.py
@@ -1,5 +1,6 @@
 import copy
 import unittest2 as unittest
+import warnings
 
 from richenum import EnumConstructionException
 from richenum import EnumLookupError
@@ -62,9 +63,11 @@ class OrderedRichEnumTestSuite(unittest.TestCase):
     def test_membership(self):
         self.assertTrue(Breakfast.COFFEE in Breakfast)
         self.assertTrue(coffee in Breakfast)
-        self.assertFalse('coffee' in Breakfast)
-        self.assertFalse('Coffee' in Breakfast)
-        self.assertFalse(0 in Breakfast)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertFalse('coffee' in Breakfast)
+            self.assertFalse('Coffee' in Breakfast)
+            self.assertFalse(0 in Breakfast)
 
     def test_public_members_must_be_ordered(self):
         # Can't mix OrderedRichEnumValues and RichEnumValues.
@@ -74,24 +77,28 @@ class OrderedRichEnumTestSuite(unittest.TestCase):
                 TEA = RichEnumValue('tea', 'Tea')
 
     def test_less_than_other_types(self):
-        # RichEnumValues are always < values of other types
-        self.assertLess(Breakfast.COFFEE, Breakfast.COFFEE.canonical_name)
-        self.assertLess(Breakfast.COFFEE, Breakfast.COFFEE.index)
-        self.assertLess(Breakfast.COFFEE, {'foo': 'bar'})
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Clean test output
+            # RichEnumValues are always < values of other types
+            self.assertLess(Breakfast.COFFEE, Breakfast.COFFEE.canonical_name)
+            self.assertLess(Breakfast.COFFEE, Breakfast.COFFEE.index)
+            self.assertLess(Breakfast.COFFEE, {'foo': 'bar'})
 
-        # ...even if the other type is also descended from OrderedRichEnumValue
-        other_coffee = OrderedRichEnumValue(0, 'coffee', 'Coffee')
-        self.assertLess(Breakfast.COFFEE, other_coffee)
+            # ...even if the other type is also descended from OrderedRichEnumValue
+            other_coffee = OrderedRichEnumValue(0, 'coffee', 'Coffee')
+            self.assertLess(Breakfast.COFFEE, other_coffee)
 
     def test_not_equal_to_other_types(self):
-        # RichEnumValues are always != values of other types
-        self.assertNotEqual(Breakfast.COFFEE, Breakfast.COFFEE.canonical_name)
-        self.assertNotEqual(Breakfast.COFFEE, Breakfast.COFFEE.index)
-        self.assertNotEqual(Breakfast.COFFEE, {'foo': 'bar'})
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Clean test output
+            # RichEnumValues are always != values of other types
+            self.assertNotEqual(Breakfast.COFFEE, Breakfast.COFFEE.canonical_name)
+            self.assertNotEqual(Breakfast.COFFEE, Breakfast.COFFEE.index)
+            self.assertNotEqual(Breakfast.COFFEE, {'foo': 'bar'})
 
-        # ...even if the other type is also descended from OrderedRichEnumValue
-        other_coffee = OrderedRichEnumValue(0, 'coffee', 'coffee')
-        self.assertNotEqual(Breakfast.COFFEE, other_coffee)
+            # ...even if the other type is also descended from OrderedRichEnumValue
+            other_coffee = OrderedRichEnumValue(0, 'coffee', 'coffee')
+            self.assertNotEqual(Breakfast.COFFEE, other_coffee)
 
     def test_compares_by_index(self):
         self.assertLess(Breakfast.COFFEE, Breakfast.OATMEAL)
@@ -101,3 +108,9 @@ class OrderedRichEnumTestSuite(unittest.TestCase):
         coffee_copy = copy.deepcopy(Breakfast.COFFEE)
         self.assertFalse(coffee_copy is Breakfast.COFFEE)
         self.assertEqual(Breakfast.COFFEE, coffee_copy)
+
+    def test_comparisons_to_other_types_raise_warnings(self):
+        with warnings.catch_warnings(record=True) as warnings_raised:
+            self.assertNotEqual(Breakfast.COFFEE, 0)
+            self.assertLess(Breakfast.COFFEE, 'coffee')
+            self.assertEqual(len(warnings_raised), 2)

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -1,5 +1,6 @@
 import copy
 import unittest2 as unittest
+import warnings
 
 from richenum import EnumConstructionException
 from richenum import EnumLookupError
@@ -36,9 +37,11 @@ class RichEnumTestSuite(unittest.TestCase):
 
     def test_membership(self):
         self.assertTrue(Vegetable.OKRA in Vegetable)
-        # Doesn't work with canonical or display names.
-        self.assertFalse('okra' in Vegetable)
-        self.assertFalse('Okra' in Vegetable)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            # Doesn't work with canonical or display names.
+            self.assertFalse('okra' in Vegetable)
+            self.assertFalse('Okra' in Vegetable)
 
         parsnip = VegetableEnumValue('yum', 'parsnip', 'Parsnip')
         self.assertFalse(parsnip in Vegetable)
@@ -89,24 +92,28 @@ class RichEnumTestSuite(unittest.TestCase):
             self.fail('RichEnum should allow private attributes of any type.')
 
     def test_less_than_other_types(self):
-        # RichEnumValues are always < values of other types
-        self.assertLess(Vegetable.OKRA, Vegetable.OKRA.canonical_name)
-        self.assertLess(Vegetable.OKRA, 11)
-        self.assertLess(Vegetable.OKRA, {'foo': 'bar'})
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Clean test output
+            # RichEnumValues are always < values of other types
+            self.assertLess(Vegetable.OKRA, Vegetable.OKRA.canonical_name)
+            self.assertLess(Vegetable.OKRA, 11)
+            self.assertLess(Vegetable.OKRA, {'foo': 'bar'})
 
-        # ...even if the other type is also descended from RichEnumValue
-        other_okra = RichEnumValue('okra', 'Okra')
-        self.assertLess(Vegetable.OKRA, other_okra)
+            # ...even if the other type is also descended from RichEnumValue
+            other_okra = RichEnumValue('okra', 'Okra')
+            self.assertLess(Vegetable.OKRA, other_okra)
 
     def test_not_equal_to_other_types(self):
-        # RichEnumValues are always != values of other types
-        self.assertNotEqual(Vegetable.OKRA, Vegetable.OKRA.canonical_name)
-        self.assertNotEqual(Vegetable.OKRA, 11)
-        self.assertNotEqual(Vegetable.OKRA, {'foo': 'bar'})
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Clean test output
+            # RichEnumValues are always != values of other types
+            self.assertNotEqual(Vegetable.OKRA, Vegetable.OKRA.canonical_name)
+            self.assertNotEqual(Vegetable.OKRA, 11)
+            self.assertNotEqual(Vegetable.OKRA, {'foo': 'bar'})
 
-        # ...even if the other type is also descended from RichEnumValue
-        other_okra = RichEnumValue('okra', 'Okra')
-        self.assertNotEqual(Vegetable.OKRA, other_okra)
+            # ...even if the other type is also descended from RichEnumValue
+            other_okra = RichEnumValue('okra', 'Okra')
+            self.assertNotEqual(Vegetable.OKRA, other_okra)
 
     def test_compares_by_canonical_name(self):
         # 'broccoli' < 'okra'
@@ -117,3 +124,9 @@ class RichEnumTestSuite(unittest.TestCase):
         okra_copy = copy.deepcopy(Vegetable.OKRA)
         self.assertFalse(okra_copy is Vegetable.OKRA)
         self.assertEqual(Vegetable.OKRA, okra_copy)
+
+    def test_comparisons_to_other_types_raise_warnings(self):
+        with warnings.catch_warnings(record=True) as warnings_raised:
+            self.assertNotEqual(Vegetable.OKRA, 'okra')
+            self.assertLess(Vegetable.OKRA, 'okra')
+            self.assertEqual(len(warnings_raised), 2)


### PR DESCRIPTION
When comparing *EnumValues to other types, raise an `EnumComparisonWarning`. The warning doesn't stop execution or change the current behavior, but it should help track down code that hasn't been fully migrated yet.

/review @adepue @dhui 
