### PR TITLE
Assert that all members of a RichEnum are the same concrete type

### DIFF
--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -145,6 +145,7 @@ def _setup_members(cls_attrs, cls_parents, member_cls):
         # Find qualified "EnumValue" attributes.
         # Field names must be UPPERCASE, not prefixed with _ ("internal"),
         # and values must be EnumValue-derived.
+        last_type = None
         for attr_key, attr_value in cls_attrs.items():
             # Skip "internal" attributes
             if attr_key.startswith("_"):
@@ -157,6 +158,13 @@ def _setup_members(cls_attrs, cls_parents, member_cls):
                 members.append(attr_value)
             else:
                 raise EnumConstructionException("Invalid attribute: %s" % attr_key)
+
+            attr_type = type(attr_value)
+            if last_type and attr_type != last_type:
+                raise EnumConstructionException("Differing member types: have seen %s,"
+                                                " encountered %s" % (last_type, attr_type))
+            else:
+                last_type = attr_type
 
         if cls_parents not in [(object, ), (_EnumMethods, )] and not members:
             raise EnumConstructionException(

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -80,6 +80,12 @@ class RichEnumTestSuite(unittest.TestCase):
                 OKRA = okra
                 PARSNIP = 'parsnip'
 
+    def test_public_members_must_be_same_concrete_type(self):
+        with self.assertRaisesRegexp(EnumConstructionException, 'Differing member types'):
+            class Medley(RichEnum):
+                OKRA = okra
+                PARSNIP = RichEnumValue('carrot', 'Carrot')
+
     def test_private_members_can_be_anything(self):
         try:
             class Medley(RichEnum):


### PR DESCRIPTION
Having differing RichEnumValue subclasses used in the same RichEnum has proven to be the source of many subtle bugs.

This does make RichEnum slightly less flexible, but in our view the tradeoff is worth it.
