### PR TITLE
Membership tests without cross-type comparisons

### DIFF
--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -174,6 +174,15 @@ class _BaseRichEnumMetaclass(type):
     def __len__(cls):
         return len(cls._MEMBERS)
 
+    def __contains__(cls, item):
+        # Check membership without comparing enum values to other types.
+        members = cls.members()
+        if not members:
+            return False
+        if not type(members[0]) == type(item):
+            return False
+        return (item in members)
+
 
 class _RichEnumMetaclass(_BaseRichEnumMetaclass):
     def __new__(cls, cls_name, cls_parents, cls_attrs):

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -37,11 +37,10 @@ class RichEnumTestSuite(unittest.TestCase):
 
     def test_membership(self):
         self.assertTrue(Vegetable.OKRA in Vegetable)
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            # Doesn't work with canonical or display names.
-            self.assertFalse('okra' in Vegetable)
-            self.assertFalse('Okra' in Vegetable)
+
+        # Doesn't work with canonical or display names.
+        self.assertFalse('okra' in Vegetable)
+        self.assertFalse('Okra' in Vegetable)
 
         parsnip = VegetableEnumValue('yum', 'parsnip', 'Parsnip')
         self.assertFalse(parsnip in Vegetable)


### PR DESCRIPTION
Override `__contains__` so we can check membership without triggering the cross-type comparison warnings.

/review @adepue 
