### PR TITLE
Remove warning messages when making lookup() calls against members that are lists by checking to see if the member is an iterable first.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Contributors
 | `Akshay Shah <http://github.com/akshayjshah>`_
 | `Dale Hui <http://github.com/dhui>`_
 | `Robert MacCloy <http://github.com/rbm>`_
+| `Roger Hu <http://github.com/rogerhu>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.0.3 (2013-11-27)
+------------------
+    -  Remove warning messages when making lookup() calls against members that are lists
+    by checking to see if the member is an iterable first.
+
 1.0.2 (2013-11-05)
 ------------------
     - Suppress warnings from mismatched type comparisons when generated

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
 
 setup(
     name='richenum',
-    version='1.0.2',
+    version='1.0.3',
     description='Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -249,18 +249,18 @@ class _EnumMethods(object):
             # though the calling pattern is acceptable.
             # n.b. There's likely a cleaner way to fix this but I was unsure if
             # doing so would break the semantics of this method.
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                if member_value == value:
-                    return member
-
             if (
                 not isinstance(member_value, str) and
                 not isinstance(member_value, unicode) and
-                isinstance(member_value, collections.Iterable) and
-                value in member_value
-            ):
-                return member
+                    isinstance(member_value, collections.Iterable)):
+                if value in member_value:
+                    return member
+            else:
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    if member_value == value:
+                        return member
+
         raise EnumLookupError('Could not find member matching %s = %s in enum %s'
                               % (field, value, cls)
                               )


### PR DESCRIPTION
Fixing some issues with false warnings.

@dhui @akshayjshah 
