### PR TITLE
Add LookupError members to RichEnums to simplify catching lookup errors, and bump version to 1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.2.0 (2016-04-15)
+------------------
+    - added simple ``LookupError`` members that are thrown when
+      ``RichEnum.lookup`` is called for a nonexistent attr/val pair.
+      Users can choose to catch either the specific ``LookupError`` or
+      continue to catch ``EnumLookupError``.
+
 1.1.0 (2014-04-17)
 ------------------
     - support for Python 3 and PyPy

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info.major == 2:
 
 setup(
     name='richenum',
-    version='1.1.2',
+    version='1.2.0',
     description='Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -231,6 +231,7 @@ class _RichEnumMetaclass(_BaseRichEnumMetaclass):
         members = _setup_members(cls_attrs, cls_parents, RichEnumValue)
         # Use tuple when possible when setting internal attributes to prevent modification
         cls_attrs['_MEMBERS'] = tuple(members)
+        cls_attrs['LookupError'] = type('LookupError', (EnumLookupError,), {})
         return super(_RichEnumMetaclass, cls).__new__(cls, cls_name, cls_parents, cls_attrs)
 
 
@@ -241,6 +242,7 @@ class _OrderedRichEnumMetaclass(_BaseRichEnumMetaclass):
 
         # Use tuple when possible when setting internal attributes to prevent modification
         cls_attrs['_MEMBERS'] = tuple(members)
+        cls_attrs['LookupError'] = type('LookupError', (EnumLookupError,), {})
 
         # we want to validate that there are not two items at the same index, so lets do that here
         seen = set()
@@ -278,7 +280,7 @@ class _EnumMethods(object):
                 value in member_value
             ):
                 return member
-        raise EnumLookupError('Could not find member matching %s = %s in enum %s'
+        raise cls.LookupError('Could not find member matching %s = %s in enum %s'  # pylint: disable=no-member
                               % (field, value, cls)
                               )
 

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 # pylint: disable=E1101
 
@@ -147,3 +148,16 @@ class RichEnumTestSuite(unittest.TestCase):
         self.assertEqual(str(poop_okra), "Okra💩")
         if not PY3:
             self.assertEqual(unicode(poop_okra), u"Okra💩")
+
+    def test_specific_lookup_error_is_caught(self):
+        with self.assertRaises(Vegetable.LookupError):
+            Vegetable.lookup('canonical_name', 'meat')
+
+    def test_other_specific_lookup_error_is_not_caught(self):
+        class Meat(RichEnum):
+            COW = RichEnumValue("cow", "Cow")
+
+        with self.assertRaises(EnumLookupError) as cm:
+            Vegetable.lookup('canonical_name', 'meat')
+
+        self.assertNotIsInstance(cm.exception, Meat.LookupError)


### PR DESCRIPTION
Similar to how `DoesNotExist` works in Django, etc, add a type-specific `EnumLookupError` subclass to each constructed `RichEnum`-derived class, so
that
1) Users can avoid having to import `EnumLookupError` specifically
2) Users can choose to catch `LookupError`s for only specific enums

Also added tests.
