### PR TITLE
Remove restriction that all enum values must be the same concrete type.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.3.0 (2017-07-20)
+------------------
+    - Member types may be of any concrete type as long as they
+      all extend ``RichEnumValue`` or ``OrderedRichEnumValue``
+      (depending on the type of RichEnum).
+
 1.2.1 (2016-09-16)
 ------------------
     - ``EnumLookupError`` class now inherits from built-in ``LookupError``.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info.major == 2:
 
 setup(
     name='richenum',
-    version='1.2.1',
+    version='1.3.0',
     description='Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -178,7 +178,6 @@ def _setup_members(cls_attrs, cls_parents, member_cls):
         # Find qualified "EnumValue" attributes.
         # Field names must be UPPERCASE, not prefixed with _ ("internal"),
         # and values must be EnumValue-derived.
-        last_type = None
         for attr_key, attr_value in cls_attrs.items():
             # Skip "internal" attributes
             if attr_key.startswith("_"):
@@ -191,13 +190,6 @@ def _setup_members(cls_attrs, cls_parents, member_cls):
                 members.append(attr_value)
             else:
                 raise EnumConstructionException("Invalid attribute: %s" % attr_key)
-
-            attr_type = type(attr_value)
-            if last_type and attr_type != last_type:
-                raise EnumConstructionException("Differing member types: have seen %s,"
-                                                " encountered %s" % (last_type, attr_type))
-            else:
-                last_type = attr_type
 
         if "__virtual__" not in cls_attrs and cls_parents not in [
                 (object, ), (_EnumMethods, )

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -91,11 +91,10 @@ class RichEnumTestSuite(unittest.TestCase):
                 OKRA = okra
                 PARSNIP = 'parsnip'
 
-    def test_public_members_must_be_same_concrete_type(self):
-        with self.assertRaisesRegexp(EnumConstructionException, 'Differing member types'):
-            class Medley(RichEnum):
-                OKRA = okra
-                PARSNIP = RichEnumValue('carrot', 'Carrot')
+    def test_public_members_can_be_different_concrete_richenumvalue_type(self):
+        class Medley(RichEnum):
+            OKRA = okra
+            PARSNIP = RichEnumValue('carrot', 'Carrot')
 
     def test_private_members_can_be_anything(self):
         try:


### PR DESCRIPTION
I came across a use of this where I can replace a Factory doing something like:

```
class AbstractConnectorValue(RichEnumValue):
    def get_connector(self):
        raise NotImplementedError()

class Vendor1ConnectorValue(AbstractConnectorValue):
    def get_connector(self):
        # vendor-specific connector instantiation

# other Values follow
```

And even though these all inherit from the same class (either the `RichEnumValue` or the `AbstractConnectorValue`, there is no way to allow this when using the RichEnum.

So, I humbly submit this PR to remove that restriction. The restriction that the type must inherit from a `RichEnumValue` or `OrderedRichEnumValue` still exists in the code.

I couldn't think of a good reason why the restriction had to be there, given duck-typing, but maybe someone watching this repo has one? :)

/review @adepue @rbm @dhui 