### PR TITLE
Fixing __str__ implementation in python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='richenum',
-    version='1.3.0',
+    version='1.3.1',
     description='Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/richenum/enums.py
+++ b/src/richenum/enums.py
@@ -104,7 +104,7 @@ class RichEnumValue(object):
         return unicode(self.display_name)
 
     def __str__(self):
-        return self.display_name if PY3 else unicode(self).encode(
+        return str(self.display_name) if PY3 else unicode(self).encode(
             'utf-8', 'xmlcharrefreplace')
 
     def __hash__(self):

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -140,10 +140,10 @@ class RichEnumTestSuite(unittest.TestCase):
     def test_unicode_handling(self):
         poop_okra = VegetableEnumValue('gross', u'okra💩', u'Okra💩')
         exp = re.compile(r"<VegetableEnumValue: okra..? \('Okra..?'\)>")
-        assert exp.search(repr(poop_okra)) is not None
-        assert str(poop_okra) == "Okra💩"
+        self.assertIsNotNone(exp.search(repr(poop_okra)))
+        self.assertEqual(str(poop_okra), "Okra💩")
         if not six.PY3:
-            assert unicode(poop_okra) == u"Okra💩"
+            self.assertEqual(unicode(poop_okra), u"Okra💩")
 
     def test_string_coercion(self):
         class DisplayProxy():
@@ -154,7 +154,7 @@ class RichEnumTestSuite(unittest.TestCase):
                 return self.name
 
         proxy_okra = VegetableEnumValue('gross', 'okra', DisplayProxy('okra'))
-        assert '%s' % (proxy_okra) == 'okra'
+        self.assertEqual('%s' % (proxy_okra), 'okra')
 
     def test_specific_lookup_error_is_caught(self):
         with self.assertRaises(Vegetable.LookupError):

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -149,10 +149,10 @@ class RichEnumTestSuite(unittest.TestCase):
         class DisplayProxy():
             def __init__(self, name):
                 self.name = name
-            
+
             def __str__(self):
                 return self.name
-        
+
         proxy_okra = VegetableEnumValue('gross', 'okra', DisplayProxy('okra'))
         assert '%s' % (proxy_okra) == 'okra'
 

--- a/tests/richenum/test_rich_enums.py
+++ b/tests/richenum/test_rich_enums.py
@@ -145,6 +145,17 @@ class RichEnumTestSuite(unittest.TestCase):
         if not six.PY3:
             assert unicode(poop_okra) == u"Okra💩"
 
+    def test_string_coercion(self):
+        class DisplayProxy():
+            def __init__(self, name):
+                self.name = name
+            
+            def __str__(self):
+                return self.name
+        
+        proxy_okra = VegetableEnumValue('gross', 'okra', DisplayProxy('okra'))
+        assert '%s' % (proxy_okra) == 'okra'
+
     def test_specific_lookup_error_is_caught(self):
         with self.assertRaises(Vegetable.LookupError):
             Vegetable.lookup('canonical_name', 'meat')


### PR DESCRIPTION
This fixes an issue in python 3 where if display_name is not a string (for instance, when it's a proxy of some kind), then the result of `__str__` is not a string.