### PR TITLE
Fix Readme syntax because the deployment failing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,26 @@
+=========
 Changelog
 =========
 
+------------------
+2.0.1 (2024-06-06)
+------------------
+    - Fix README.rst
+
+------------------
+2.0.0 (2024-06-04)
+------------------
+    - Remove six
+    - Remove python 3.7 support
+    - Add python 3.9 and 3.10 support
+    - Remove tox.ini
+
+------------------
 1.2.1 (2016-09-16)
 ------------------
     - ``EnumLookupError`` class now inherits from built-in ``LookupError``.
 
+------------------
 1.2.0 (2016-04-15)
 ------------------
     - added simple ``LookupError`` members that are thrown when
@@ -12,36 +28,35 @@ Changelog
       Users can choose to catch either the specific ``LookupError`` or
       continue to catch ``EnumLookupError``.
 
+------------------
 1.1.0 (2014-04-17)
 ------------------
     - support for Python 3 and PyPy
 
+------------------
 1.0.4 (2013-12-03)
 ------------------
     - Better unicode handling in ``__str__``, ``__unicode__``, and
       ``__repr__`` magic methods.
 
+------------------
 1.0.3 (2013-12-03)
 ------------------
     - Stop throwing warnings.
 
+------------------
 1.0.2 (2013-11-05)
 ------------------
     - Suppress warnings from mismatched type comparisons when generated
       in RichEnum.lookup.
 
+------------------
 1.0.1 (2013-09-20)
 ------------------
     - Raise warnings when comparing enum values to other types, but not
       when checking membership or comparing to None.
 
+------------------
 1.0.0 (2013-08-16)
 ------------------
     - Initial public release.
-
-2.0.0 (2024-06-04)
-------------------
-    - Remove six
-    - Remove python 3.7 support
-    - Add python 3.9 and 3.10 support
-    - Remove tox.ini

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ OrderedRichEnum
 -----
 Links
 -----
-| `GitHub <https://github.com/hearsaycorp/richenum>`_
-| `PyPi <https://pypi.python.org/pypi/richenum/>`_
+| `GitHub <https://github.com/hearsaycorp/richenum>`__
+| `PyPi <https://pypi.python.org/pypi/richenum/>`__
 | `Blog post about the motivation behind RichEnum <http://engineering.hearsaysocial.com/2013/09/16/enums-in-python/>`_
 
 ============
@@ -46,9 +46,9 @@ Installation
 
     $ pip install richenum
 
-=====
+=============
 Example Usage
-=====
+=============
 ----
 enum
 ----
@@ -102,9 +102,9 @@ Related Packages
 django-richenum
   Makes RichEnum and OrderedRichEnum available in as model fields and form fields in Django.
 
-  | `GitHub <https://github.com/hearsaycorp/django-richenum>`_
+  | `GitHub <https://github.com/hearsaycorp/django-richenum>`__
 
-  | `PyPi <https://pypi.python.org/pypi/django-richenum/>`_
+  | `PyPi <https://pypi.python.org/pypi/django-richenum/>`__
 
 enum
   Starting with Python 3.4, there is a standard library for enumerations.
@@ -116,7 +116,7 @@ enum
 Contributing
 ============
 
-#. Fork the repo from `GitHub <https://github.com/hearsaycorp/richenum>`_.
+#. Fork the repo from `GitHub <https://github.com/hearsaycorp/richenum>`__.
 #. Make your changes.
 #. Add unittests for your changes.
 #. Run `pep8 <https://pypi.python.org/pypi/pep8>`_, `pyflakes <https://pypi.python.org/pypi/pyflakes>`_, and `pylint <https://pypi.python.org/pypi/pyflakes>`_ to make sure your changes follow the Python style guide and doesn't have any errors.

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ from setuptools import setup, find_packages
 
 setup(
     name='richenum',
-    version='2.0.0',
+    version='2.0.1',
     description='Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +
         open('CHANGELOG.rst').read() + '\n\n' +
         open('AUTHORS.rst').read()),
+    long_description_content_type='text/x-rst',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
```
❯ python -m twine upload dist/*
Uploading distributions to https://upload.pypi.org/legacy/
Uploading richenum-2.0.0-py2.py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.6/17.6 kB • 00:00 • 6.5 MB/s
WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more
         information.
```

```
INFO     <html>
          <head>
           <title>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type
         for more information.</title>
          </head>
          <body>
           <h1>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for
         more information.</h1>
           The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
         The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more
         information.
```

```
❯ python -m twine check dist/*
Checking dist/richenum-2.0.0-py2.py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 49: Warning: Title overline too short.

         =====
         Example Usage
         =====
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/richenum-2.0.0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 49: Warning: Title overline too short.

         =====
         Example Usage
         =====
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
```