### PR TITLE
Update python-version-tests.yml

### DIFF
--- a/.github/workflows/python-version-tests.yml
+++ b/.github/workflows/python-version-tests.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
-      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      uses: snok/install-poetry@v1 # v1.4.1
       with:
         version: 1.8.3
         virtualenvs-create: true


### PR DESCRIPTION
This is what every other repo does so I think it's a safe @v1 situation. the previous hash broke due to authorization but I want to try this before going to SRE to authorize the hash version.