### PR TITLE
use public github action for pypi release

### DIFF
--- a/.github/workflows/client_build.yml
+++ b/.github/workflows/client_build.yml
@@ -7,8 +7,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  call-workflow:
-    uses: hearsaycorp/github-action-templates/.github/workflows/client_build.yaml@main
-    with: 
-      repository_url: https://pypi.python.org/simple
-    secrets: inherit
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/richenum
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I'm trying to use the publicly available pypi github action to see if that will allow us to deploy this without the terminal.